### PR TITLE
Add empty output to prevent starting a job for an empty matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       files: ${{ steps.produce-matrix.outputs.files }}
+      empty: ${{ steps.produce-matrix.outputs.empty }}
     steps:
       - uses: actions/checkout@v2
 
@@ -25,6 +26,7 @@ jobs:
 
   package-lint:
     needs: produce-packages-matrix
+    if: ${{ needs.produce-packages-matrix.outputs.empty == 'false' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,13 @@ inputs:
     description: >
       Personal access token (PAT) used to make GitHub API calls
     default: ${{ github.token }}
+outputs:
+  files:
+    description: >
+      List of changed files or directories
+  empty:
+    description: >
+      Set to true if no modified files or folders were found
 runs:
   using: "node12"
   main: "dist/index.js"

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -102,6 +102,7 @@ for (const event of events) {
           "packages/package-1/package.json",
           "packages/package-2/package.json",
         ],
+        empty: false,
       })
     })
 
@@ -138,6 +139,7 @@ for (const event of events) {
           "packages/package-1/package.json",
           "packages/package-2/package.json",
         ],
+        empty: false,
       })
     })
 
@@ -173,6 +175,7 @@ for (const event of events) {
           "packages/package-2/",
           "packages/package-3/",
         ],
+        empty: false,
       })
     })
 
@@ -211,6 +214,7 @@ for (const event of events) {
           "packages/package-2/",
           "packages/package-3/",
         ],
+        empty: false,
       })
     })
 
@@ -244,6 +248,41 @@ for (const event of events) {
 
       expect(result).toEqual({
         files: ["packages/package-1/", "packages/package-2/"],
+        empty: false,
+      })
+    })
+
+    test("should return empty files list", async () => {
+      const gh = new GitHub({
+        compareFilesData: [
+          {
+            before: event.sha.before,
+            after: event.sha.after,
+            files: [
+              {
+                filename: "packages/package-1/package.json",
+                status: "modified",
+              },
+              { filename: "packages/package-2/package.json", status: "added" },
+              {
+                filename: "packages/package-3/package.json",
+                status: "removed",
+              },
+            ],
+          },
+        ],
+      })
+
+      const result = await getChangedFiles({
+        gh,
+        inputs: { files: "src/*" },
+        event: event.event,
+        log,
+      })
+
+      expect(result).toEqual({
+        files: [],
+        empty: true,
       })
     })
   })

--- a/src/get-changed-files.ts
+++ b/src/get-changed-files.ts
@@ -64,17 +64,6 @@ interface Log {
   debug: (data: any) => void
 }
 
-function isEmptyArray(value: unknown) {
-  if (!Array.isArray(value)) {
-    throw new Error("Is not an array")
-  }
-
-  if ((value as any[]).length === 0) {
-    return true
-  }
-  return false
-}
-
 export async function getChangedFiles({
   gh,
   inputs,
@@ -167,6 +156,6 @@ export async function getChangedFiles({
 
   return {
     files,
-    empty: isEmptyArray(files),
+    empty: files.length === 0,
   }
 }

--- a/src/get-changed-files.ts
+++ b/src/get-changed-files.ts
@@ -66,13 +66,12 @@ interface Log {
 
 function isEmptyArray(value: unknown) {
   if (!Array.isArray(value)) {
-    return false
+    throw new Error("Is not an array")
   }
 
   if ((value as any[]).length === 0) {
     return true
   }
-
   return false
 }
 

--- a/src/get-changed-files.ts
+++ b/src/get-changed-files.ts
@@ -64,6 +64,18 @@ interface Log {
   debug: (data: any) => void
 }
 
+function isEmptyArray(value: unknown) {
+  if (!Array.isArray(value)) {
+    return false
+  }
+
+  if ((value as any[]).length === 0) {
+    return true
+  }
+
+  return false
+}
+
 export async function getChangedFiles({
   gh,
   inputs,
@@ -89,6 +101,7 @@ export async function getChangedFiles({
   if (isFirstPushOfBranch) {
     return {
       files: [],
+      empty: true,
     }
   }
 
@@ -151,8 +164,10 @@ export async function getChangedFiles({
   ).filter(Boolean)
 
   log.info({ matchedChangedExistingDirectories })
+  const files = [...matchingFiles, ...matchedChangedExistingDirectories]
 
   return {
-    files: [...matchingFiles, ...matchedChangedExistingDirectories],
+    files,
+    empty: isEmptyArray(files),
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,7 @@ async function run(): Promise<void> {
     log.info({ result })
 
     core.setOutput("files", result.files)
+    core.setOutput("empty", result.empty)
   } catch (error) {
     core.setFailed(error.message)
   }


### PR DESCRIPTION
Now, if as a result of creating a PR or push event, there were no changes in files or folders that fit the filter of this github action, then the matrix will have an empty array
```
strategy:
      matrix:
        package: ${{ fromJson(needs.produce-packages-matrix.outputs.files) }}
```

This will cause this error in github workflow:
<img width="1042" alt="изображение" src="https://user-images.githubusercontent.com/869777/115972813-587a1400-a559-11eb-8813-361ab3128e8b.png">

Alternatively, we can add a variable named "empty" to the output of this github action and run the dependent job, provided that the value ' empty = = false`
