### PR TITLE
Fix getting a list of modified files when adding commits to existing PR

### DIFF
--- a/src/get-changed-files.ts
+++ b/src/get-changed-files.ts
@@ -47,7 +47,7 @@ function getBeforeAfterShas(event: GitHubEvent) {
   if (isGitHubPullRequestEvent(event)) {
     return {
       before: event.pull_request.base.sha,
-      after: event.pull_request.merge_commit_sha || event.pull_request.head.sha,
+      after: event.pull_request.head.sha,
     }
   } else if (isGitHubPushEvent(event)) {
     return {


### PR DESCRIPTION
To get the sha of the current commit in PR, we should use only `event.pull_request.head.sha`

The `event.pull_request.merge_commit_sha` variable contains the value of the test virtual merge commit, which is used to check the possibility of merging PR

In addition, at the time of GA launch, this variable contains the sha value of the test commit from the previous GA launch (a commit for which verification has already been performed). This virtual test commit is equal to the commit that was current at the time of the previous GA launch

If you get PR information via the API after a while, the response will contain a different value for `merge_commit_sha`. That virtual commit will be equal to the current actual commit in PR branch

All this causes the following behavior:
1. If you add another folder to PR and make a commit, then in the output of action the folder will not be in `changeDirectories`
2. If you add another folder and commit, then in the output of action, the folder from step.1 will be added to `changeDirectories`
3. You can not add a folder in step.2, but instead make an amend commit, then the folder from step.1 will also be added to `changeDirectories` (because `merge_commit_sha` refers to the sha of the commit that was current at the time of the previous GA launch)

**Useful Links:**
1. [GitHub REST API Documentation](https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request)
2. [Information about test merge commit](https://stackoverflow.com/a/22341509)