### PR TITLE
Fix large number of files

### DIFF
--- a/src/__tests__/events/pull_request_event.ts
+++ b/src/__tests__/events/pull_request_event.ts
@@ -1,6 +1,6 @@
 export default {
   pull_request: {
-    merge_commit_sha: "68618f6c025adae7b025f32ab5957c5bdbe2e248",
+    number: 2,
     base: {
       sha: "1d0dcb00ed0867f433437a150e9210dec9cbc33b",
     },

--- a/src/get-changed-files.ts
+++ b/src/get-changed-files.ts
@@ -119,7 +119,7 @@ export async function getChangedFiles({
     ref: getRef(event),
   })
 
-  log.info({
+  log.debug({
     allChangedFiles: changedFiles.map((f) => ({
       filename: f.filename,
       status: f.status,
@@ -132,18 +132,18 @@ export async function getChangedFiles({
     .filter((file) => file.status !== "removed")
     .map((file) => file.filename)
 
-  log.info({ existingFiles })
+  log.debug({ existingFiles })
 
   const matchingFiles = existingFiles.filter((fileName) =>
     filesGlobs
       .filter((glob) => !glob.endsWith("/"))
       .some((glob) => minimatch(fileName, glob))
   )
-  log.info({ matchingFiles })
+  log.debug({ matchingFiles })
 
   const changedDirectories = getChangedDirectories(changedFiles)
 
-  log.info({ changedDirectories })
+  log.debug({ changedDirectories })
 
   const matchedChangedDirectories = changedDirectories.filter((fileName) =>
     filesGlobs
@@ -151,7 +151,7 @@ export async function getChangedFiles({
       .some((glob) => minimatch(fileName.dirname, glob))
   )
 
-  log.info({ matchedChangedDirectories })
+  log.debug({ matchedChangedDirectories })
 
   const matchedChangedExistingDirectories = (
     await Promise.all(
@@ -170,7 +170,7 @@ export async function getChangedFiles({
     )
   ).filter(Boolean)
 
-  log.info({ matchedChangedExistingDirectories })
+  log.debug({ matchedChangedExistingDirectories })
   const files = [...matchingFiles, ...matchedChangedExistingDirectories]
 
   return {


### PR DESCRIPTION
Fixes #29

### Change Description

The output of the octokit.test.repos.compareCommits function contains a limited number of files that have been modified by the specified commits (300 files).
Pagination in this function is used only to output a list of commits. The list of modified files is contained only on the first page with the same limit of 300 files.

In Octokit rest.js there are two functions for which pagination is used to output a list of modified files:
- `octokit.rest.pulls.listFiles` - to get files modified in PR
- `octokit.test.repos.gitCommit` - to get the files modified in the commit

I use the `octokit.paginate.iterator` function to paginate over the outputs of these functions

### GitHub API Limitation

Unfortunately, the GitHub API continues to have a limit of 3000 files for listing, but this is better than 300:
 - [List pull requests files](https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files)
 - [Get a commit](https://docs.github.com/en/rest/commits/commits#get-a-commit)

These limitations are also mentioned in the [Octokit rest.js documentation](https://octokit.github.io/rest.js/v18/)

### Debug Logging

I also changed the logging level to output debugging information.
[Debugging mode](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging) for GitHub Action can be activated by creating a secret `ACTIONS_STEP_DEBUG=true` in the repository